### PR TITLE
[2기-C] 류영준 create Voucher 기능 테스트 코드 구현

### DIFF
--- a/src/test/java/kdt/vouchermanagement/VoucherConsoleControllerTest.java
+++ b/src/test/java/kdt/vouchermanagement/VoucherConsoleControllerTest.java
@@ -1,0 +1,59 @@
+package kdt.vouchermanagement;
+
+import kdt.vouchermanagement.domain.voucher.domain.VoucherType;
+import kdt.vouchermanagement.domain.voucher.dto.VoucherRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+public class VoucherConsoleControllerTest {
+
+    @InjectMocks
+    VoucherConsoleController voucherConsoleController;
+
+    @Mock
+    VoucherService voucherService;
+
+    @Test
+    @DisplayName("전달받은 DTO의 VoucherType이 유효하지 않으면_실패")
+    void invalidVoucherType() {
+        //given
+        VoucherRequest request = new VoucherRequest(VoucherType.NONE, 100);
+
+        //when, then
+        assertThrows(IllegalArgumentException.class, () -> voucherConsoleController.create(request));
+    }
+
+    @Test
+    @DisplayName("전달받은 DTO의 VoucherType이 유효하면_성공")
+    void invalidVoucherType() {
+        //given
+        VoucherRequest request = new VoucherRequest(VoucherType.FIXED_AMOUNT, 100);
+
+        //when, then
+        assertDoesNotThrow(() -> () -> voucherConsoleController.create(request));
+    }
+
+    @Test
+    @DisplayName("바우처 생성 요청_성공")
+    void requestCreateVoucher() {
+        //given
+        VoucherRequest request = new VoucherRequest(VoucherType.FIXED_AMOUNT, 100);
+
+        //then
+        voucherConsoleController.create(request);
+
+        //when
+        verify(voucherService, times(1)).createVoucher(any(VoucherRequest.class));
+    }
+}


### PR DESCRIPTION
# 📌 과제 설명
Voucher DTO에 해당하는 VoucherRequest를 Controller에서 Domain으로 변환하지 않고 Service 레이어에게 전달하도록 테스트 코드를 구현하였습니다.
* 이유 : Voucher는 VoucherRequest 내부의 VoucherType에 따라 각각의 다른 도메인이 생성됩니다. VoucherType에 따라 알맞는 도메인을 생성하기 위한 비즈니스 로직이 Service 레이어에서 이루어지고, 도메인이 생성되기 전에 거쳐야 할 비즈니스 로직도 Service 레이어에서 이루어지느 것이 바람직하다고 생각합니다.