### PR TITLE
:recycle: Refactor: 유효성 검사 위치 변경

### DIFF
--- a/src/main/java/com/waterfogsw/voucher/voucher/controller/VoucherController.java
+++ b/src/main/java/com/waterfogsw/voucher/voucher/controller/VoucherController.java
@@ -16,6 +16,8 @@ public class VoucherController {
     }
 
     public Response<VoucherDto> voucherAdd(VoucherDto request) {
+        if (request == null) return Response.error(ResponseStatus.BAD_REQUEST);
+
         try {
             Voucher savedVoucher = voucherService.saveVoucher(request.toDomain());
             return Response.ok(VoucherDto.of(savedVoucher));

--- a/src/main/java/com/waterfogsw/voucher/voucher/controller/VoucherController.java
+++ b/src/main/java/com/waterfogsw/voucher/voucher/controller/VoucherController.java
@@ -9,7 +9,6 @@ import org.springframework.stereotype.Controller;
 
 @Controller
 public class VoucherController {
-
     private final VoucherService voucherService;
 
     public VoucherController(VoucherService voucherService) {
@@ -18,17 +17,10 @@ public class VoucherController {
 
     public Response<VoucherDto> voucherAdd(VoucherDto request) {
         try {
-            validateVoucherRequest(request);
             Voucher savedVoucher = voucherService.saveVoucher(request.toDomain());
             return Response.ok(VoucherDto.of(savedVoucher));
         } catch (IllegalArgumentException e) {
             return Response.error(ResponseStatus.BAD_REQUEST);
-        }
-    }
-
-    private void validateVoucherRequest(VoucherDto request) {
-        if (request.type() == null || request.value() == 0) {
-            throw new IllegalArgumentException();
         }
     }
 }

--- a/src/main/java/com/waterfogsw/voucher/voucher/dto/VoucherDto.java
+++ b/src/main/java/com/waterfogsw/voucher/voucher/dto/VoucherDto.java
@@ -8,8 +8,13 @@ public record VoucherDto(
         int value
 ) {
 
+    public VoucherDto(VoucherType type, int value) {
+        validate(type, value);
+        this.type = type;
+        this.value = value;
+    }
+
     public Voucher toDomain() {
-        validate(type(), value());
         return Voucher.of(type(), value());
     }
 

--- a/src/main/java/com/waterfogsw/voucher/voucher/dto/VoucherDto.java
+++ b/src/main/java/com/waterfogsw/voucher/voucher/dto/VoucherDto.java
@@ -9,6 +9,7 @@ public record VoucherDto(
 ) {
 
     public Voucher toDomain() {
+        validate(type(), value());
         return Voucher.of(type(), value());
     }
 

--- a/src/test/java/com/waterfogsw/voucher/voucher/VoucherControllerTests.java
+++ b/src/test/java/com/waterfogsw/voucher/voucher/VoucherControllerTests.java
@@ -33,28 +33,13 @@ public class VoucherControllerTests {
     class Describe_voucherSave {
 
         @Nested
-        @DisplayName("바우처 타입이 null 들어오면")
+        @DisplayName("null 인 dto 가 들어오면")
         class Context_with_type_null {
 
             @Test
             @DisplayName("BadRequest Status 를 가진 응답을 리턴한다")
             void it_return_error_message() {
-                var voucherDto = new VoucherDto(null, 1000);
-                var response = controller.voucherAdd(voucherDto);
-
-                assertThat(response.status(), is(ResponseStatus.BAD_REQUEST));
-            }
-        }
-
-        @Nested
-        @DisplayName("value 값이 0 이 들어오면")
-        class Context_with_value_zero {
-
-            @Test
-            @DisplayName("BadRequest Status 를 가진 응답을 리턴한다")
-            void it_return_error_message() {
-                var voucherDto = new VoucherDto(VoucherType.FIXED_AMOUNT, 0);
-                var response = controller.voucherAdd(voucherDto);
+                var response = controller.voucherAdd(null);
 
                 assertThat(response.status(), is(ResponseStatus.BAD_REQUEST));
             }


### PR DESCRIPTION
- 유효성 검사 위치를 Dto 내부로 변경하였습니다.
- 도메인을 생성하는 로직에 유효성 검사를 추가하였는데, 도메인을 생성하기 위해 필요한 정보가 모두 들어 왔는가를 판단하기에 적절한 위치라 생각했습니다.