### PR TITLE
[2기-C] 김산 :test_tube: Test: Service 실패 테스트 시나리오 수정

### DIFF
--- a/src/test/java/com/waterfogsw/voucher/voucher/VoucherServiceTests.java
+++ b/src/test/java/com/waterfogsw/voucher/voucher/VoucherServiceTests.java
@@ -14,23 +14,12 @@ public class VoucherServiceTests {
     class Describe_addVoucher {
 
         @Nested
-        @DisplayName("type 이 FIXED_AMOUNT 인 Voucher 의 value 가 음수이면")
+        @DisplayName("repository 에서 NPE 가 발생하면")
         class Context_with_negative_fixedAmount {
 
             @Test
-            @DisplayName("IllegalArgumentException 예외를 발생시킨다.")
-            void it_throw_IllegalArgumentException() {
-
-            }
-        }
-
-        @Nested
-        @DisplayName("type 이 PERCENT_DISCOUNT 인 Voucher 의 value 가 1 ~ 100 사이의 수가 아니면")
-        class Context_with_out_of_range_percent_discount {
-
-            @Test
-            @DisplayName("IllegalArgumentException 예외를 발생시킨다.")
-            void it_throw_IllegalArgumentException() {
+            @DisplayName("RepositoryException 예외를 발생시킨다")
+            void it_throw_RepositoryException() {
 
             }
         }


### PR DESCRIPTION
- 기존 서비스에서 처리하던 도메인에 대한 유효성 검사가 domain 내부 생성자에서 진행됨에 따라 해당 테스트 코드는 제거하였습니다.
- NPE가 발생하는 경우 service레이어가 이를 잡아 처리하고, 사용자 정의 예외인 RepositoryException 예외를 발생시켜 repository에 대한 에러임을 controller에서 알수있도록 할 예정입니다.