### PR TITLE
:adhesive_bandage: fix: voucherId long -> Long 변경

### DIFF
--- a/src/main/java/kdt/vouchermanagement/domain/voucher/domain/Voucher.java
+++ b/src/main/java/kdt/vouchermanagement/domain/voucher/domain/Voucher.java
@@ -1,17 +1,17 @@
 package kdt.vouchermanagement.domain.voucher.domain;
 
 public abstract class Voucher {
-    private final long voucherId;
+    private final Long voucherId;
     private final VoucherType voucherType;
     private final int discountValue;
 
     public Voucher(VoucherType voucherType, int discountValue) {
-        this.voucherId = 0;
+        this.voucherId = null;
         this.voucherType = voucherType;
         this.discountValue = discountValue;
     }
 
-    public Voucher(long voucherId, VoucherType voucherType, int discountValue) {
+    public Voucher(Long voucherId, VoucherType voucherType, int discountValue) {
         this.voucherId = voucherId;
         this.voucherType = voucherType;
         this.discountValue = discountValue;


### PR DESCRIPTION
# 📌 과제 설명 

VoucherId의 타입을 Primitive 타입으로 구현할 수 있지만, Wrapping 타입으로도 기본값을 Null로 세팅할 수 있고 인메모리 저장 방식에서 Map<K, V> 컬렉션을 사용할 때 Primitive 타입을 지원하지 않으므로 수정하게되었습니다.