### PR TITLE
[3기-C] 정찬미 SpringBoot Part2 Weekly Mission 제출합니다

### DIFF
--- a/src/main/java/org/prgms/springbootbasic/cli/CommandLine.java
+++ b/src/main/java/org/prgms/springbootbasic/cli/CommandLine.java
@@ -33,12 +33,15 @@ public class CommandLine {
         VoucherType voucherType = VoucherType.findVoucherType(this.input.read());
         long amount = 0L;
 
-        if (voucherType == VoucherType.FIXED) {
-            this.output.print("enter amount of voucher (0 ~)");
-            amount = Long.parseLong(this.input.read());
-        } else if (voucherType == VoucherType.PERCENT) {
-            this.output.print("enter percent of voucher (0 ~ 100)");
-            amount = Long.parseLong(this.input.read());
+        switch (voucherType) {
+            case FIXED -> {
+                this.output.print("enter amount of voucher (0 ~)");
+                amount = Long.parseLong(this.input.read());
+            }
+            case PERCENT -> {
+                this.output.print("enter percent of voucher (0 ~ 100)");
+                amount = Long.parseLong(this.input.read());
+            }
         }
 
         return new VoucherCreateDTO(voucherType, amount);
@@ -76,7 +79,7 @@ public class CommandLine {
     }
 
     public UUID getVoucherCommand(String description) {
-        this.output.print("Type voucher id\t"+ description);
+        this.output.print("Type voucher id\t" + description);
         String voucherId = this.input.read();
         if (this.input.isUUID(voucherId)) {
             return UUID.fromString(voucherId);
@@ -84,6 +87,7 @@ public class CommandLine {
             throw new IllegalArgumentException("not valid uuid entered");
         }
     }
+
     public boolean stopCommandLine() {
         input.stop();
         output.stop();
@@ -102,16 +106,14 @@ public class CommandLine {
                 for (VoucherDTO item : voucherDTOS) {
                     output.print(item.toString());
                 }
-            } else if (list.get(0) instanceof Customer){
+            } else if (list.get(0) instanceof Customer) {
                 List<CustomerDTO> customerDTOS =
                         list.stream().map(c -> this.convertToCustomerDTO((Customer) c)).toList();
 
                 for (CustomerDTO item : customerDTOS) {
                     output.print(item.toString());
                 }
-            }
-
-            else {
+            } else {
                 for (Object item : list) {
                     output.print(item.toString());
                 }

--- a/src/main/java/org/prgms/springbootbasic/repository/customer/JdbcTemplateCustomerRepository.java
+++ b/src/main/java/org/prgms/springbootbasic/repository/customer/JdbcTemplateCustomerRepository.java
@@ -16,7 +16,6 @@ import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
 import org.springframework.stereotype.Repository;
 
 import javax.sql.DataSource;
-import java.sql.Timestamp;
 import java.util.*;
 
 @Repository
@@ -35,12 +34,7 @@ public class JdbcTemplateCustomerRepository implements CustomerRepository {
                 return customer;
             };
 
-    private Map<String, Object> toParamMap(Customer customer) {
-        return new HashMap<>() {{
-            put("customerId", customer.getCustomerId().toString());
-            put("lastLoginAt", customer.getLastLoginAt() != null ? Timestamp.valueOf(customer.getLastLoginAt()) : null);
-        }};
-    }
+
     private final NamedParameterJdbcTemplate jdbcTemplate;
     private final ObjectMapper objectMapper;
     private final SimpleJdbcInsert jdbcInsert;
@@ -80,8 +74,12 @@ public class JdbcTemplateCustomerRepository implements CustomerRepository {
 
     @Override
     public Customer updateLastLoginAt(Customer customer) {
+        Map <String, Object> map = Map.of(
+                "customerId", customer.getCustomerId().toString(),
+                "lastLoginAt", customer.getLastLoginAt()
+        );
         int update = jdbcTemplate.update("UPDATE CUSTOMERS SET last_login_at = :lastLoginAt WHERE customer_id = :customerId",
-                toParamMap(customer));
+                map);
         if (update != 1) {
             throw new NoAffectedRowException("Noting was updated");
         }

--- a/src/main/java/org/prgms/springbootbasic/service/VoucherService.java
+++ b/src/main/java/org/prgms/springbootbasic/service/VoucherService.java
@@ -19,20 +19,20 @@ public class VoucherService {
 
     public Voucher createVoucher(VoucherCreateDTO voucherCreateDTO)  {
 
-        if(voucherCreateDTO.voucherType() == VoucherType.PERCENT) {
-            return voucherRepository
-                    .insert(new PercentDiscountVoucher(UUID.randomUUID(),
+        switch (voucherCreateDTO.voucherType()) {
+            case PERCENT -> {
+                return voucherRepository.insert(new PercentDiscountVoucher(UUID.randomUUID(),
                             voucherCreateDTO.voucherType(),
                             voucherCreateDTO.amount()));
-        }
-        else if(voucherCreateDTO.voucherType() == VoucherType.FIXED) {
-            return voucherRepository
-                    .insert(new FixedAmountVoucher(UUID.randomUUID(),
-                            voucherCreateDTO.voucherType(),
-                            voucherCreateDTO.amount()));
-        }
-        else {
-            throw new IllegalArgumentException("invalid voucher option");
+            }
+
+            case FIXED -> {
+                return voucherRepository.insert(new FixedAmountVoucher(UUID.randomUUID(),
+                                voucherCreateDTO.voucherType(),
+                                voucherCreateDTO.amount()));
+            }
+            default ->
+                throw new IllegalArgumentException("invalid voucher option");
         }
 
     }


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->
> 리뷰 잘부탁드립니다 감사합니다 :)

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
**(기본)** **바우처 관리 애플리케이션**

- [x] 바우처 관리 애플리케이션에 단위테스트를 작성해보세요.
    - [x] 가능한 많은 단위 테스트코드를 작성하려고 노력해보세요.
    - [x] 엣지 케이스(예외 케이스)를 고려해서 작성해주세요.
    - [x] Hamcrest 의 메쳐들을 다양하게 작성해보고 익숙해져 보세요.
- [x]  바우처 관리 애플리케이션에서도 과정에서 다루었던 고객을 적용해보세요.
    - [x] customers 테이블 정의 및 추가
    - [x] CustomerRepository 추가 및 JdbcTemplate을 사용해서 구현
- [x]  (1주차엔 파일로 관리하게 했다.) 바우처 정보를 DB로 관리해보세요.
    - [x] 바우처에 엔터티에 해당하는 vouchers 테이블을 한번 정의해보세요.
    - [x] 바우처 레포지토리를 만들어보세요. (JdbcTemplate을 사용해서 구현)
    - [x] 기존의 파일에서 바우처를 관리한 것을 vouchers 테이블을 통해서 CRUD가 되게 해보세요.

**(심화)** **바우처 지갑을 만들어보세요.**

- [x] 특정 고객에게 바우처를 할당할 수 있습니다. (`MANAGE_VOUCHER`)
- [x] 고객이 어떤 바우처를 보유하고 있는지 조회할 수 있어야 합니다.  (`MANAGE_VOUCHER`)
- [x] 고객이 보유한 바우처를 제거할 수 있어야 합니다. (`MANAGE_VOUCHER`)
- [x] 특정 바우처를 보유한 고객을 조회할 수 있어야 합니다. (`FIND_CUSTOMER`)
## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
### `MANAGE_VOUCHER` 명령 실행결과

```bash
Type manage_voucher to associate customer with voucher
...
manage_voucher

Type customer id to find vouchers belonging to the customer
df7dc334-bfcb-4f93-b84a-e081ab370868
list is empty

Type yes (if not, type no) if you want to allocate a voucher to the customer
yes

VoucherDTO{voucherId=ef7a8647-46dc-42b1-8745-f74b0a252797, voucherType=FIXED, amount=10000}

Type voucher id to allocate voucher to the customer
ef7a8647-46dc-42b1-8745-f74b0a252797
```

### `FIND_CUSTOMER` 명령 실행결과
```bash
Type find_customer to find customer by voucher id

find_customer
Type voucher id to find customer information
ef7a8647-46dc-42b1-8745-f74b0a252797

CustomerDTO[customerId=df7dc334-bfcb-4f93-b84a-e081ab370868, email=migujeong@gmail.com, name=Tina]
```
## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->

- 관리할 메세지가 많아져 `Command` enum에 커맨드별 메세지 추가
- 전체적으로 voucher, customer 별 패키징
- CommandLineApplication에서 Serivce가 아닌 Controller를 주입받도록 변경  
- Repository에서 double brace initialization이 아닌 `Map.of` 사용 
- Percent, Fixed Voucher Type을 구분하는 코드에 일괄적으로 switch 적용

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- `JdbcTemplateVoucherRepository`에 `VOUCHERS_COLUMNS`이라는 상수 배열을 선언해 코드상에서 직접적인 문자열 명시를 최대한 지양해봤습니다. 그런데 camelCase로 써야하는 경우도 생겨 추가적인 상수배열을 선언하기 애매해 선언은 보류했습니다. ->  camelCase와 snakeCase로 반복되는 상수 문자열을 직접 기술해야 하는 경우가 많습니다. **상수문자열**을 어떻게 관리하는 것이 좋을까요?
- `CommandLIneApplication`의 `manageVoucher` 함수에서 시나리오를 한꺼번에 처리하다보니 데이터를 직접적으로 사용해야하는 경우가 생겨 비즈니스로직이 해당 메소드에 집중되었고, 복잡도가 높아진 경향이 있어보입니다. 개선점이 궁금합니다!
- `default_ddl.sql`에 테이블을 설계하면서 고민이 많았습니다. wallet 테이블을 별도로 생성해 정규화시키는 것이 좋을까요?