### PR TITLE
[4기-원건희] 6차 PR 제출합니다.

### DIFF
--- a/logs/access.log
+++ b/logs/access.log
@@ -1,1 +1,0 @@
-20:22:03.652 [main] ERROR c.p.console.CommandLineApplication -- Log Message -> [ERROR] 잘못된 커맨드입니다. 올바른 커맨드를 입력해 주세요. 

--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,11 @@
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>

--- a/src/main/java/com/programmers/advice/ApiException.java
+++ b/src/main/java/com/programmers/advice/ApiException.java
@@ -1,0 +1,29 @@
+package com.programmers.advice;
+
+import org.springframework.http.HttpStatus;
+
+import java.time.ZonedDateTime;
+
+public class ApiException {
+    private final String message;
+    private final HttpStatus httpStatus;
+    private final ZonedDateTime timestamp;
+
+    public ApiException(String message, HttpStatus httpStatus, ZonedDateTime timestamp) {
+        this.message = message;
+        this.httpStatus = httpStatus;
+        this.timestamp = timestamp;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    public ZonedDateTime getTimestamp() {
+        return timestamp;
+    }
+}

--- a/src/main/java/com/programmers/advice/ApiExceptionHandler.java
+++ b/src/main/java/com/programmers/advice/ApiExceptionHandler.java
@@ -1,0 +1,36 @@
+package com.programmers.advice;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.NoSuchElementException;
+
+@ControllerAdvice
+public class ApiExceptionHandler {
+
+    @ExceptionHandler(value = {NoSuchElementException.class})
+    public ResponseEntity<Object> handleNoSuchElementException(NoSuchElementException e) {
+        HttpStatus httpStatus = HttpStatus.BAD_REQUEST;
+        ApiException apiException = new ApiException(
+                e.getMessage(),
+                httpStatus,
+                ZonedDateTime.now(ZoneId.of("Z"))
+        );
+        return new ResponseEntity<>(apiException, httpStatus);
+    }
+
+    @ExceptionHandler(value = {IllegalArgumentException.class})
+    public ResponseEntity<Object> handleIllegalArgumentException(IllegalArgumentException e) {
+        HttpStatus httpStatus = HttpStatus.BAD_REQUEST;
+        ApiException apiException = new ApiException(
+                e.getMessage(),
+                httpStatus,
+                ZonedDateTime.now(ZoneId.of("Z"))
+        );
+        return new ResponseEntity<>(apiException, httpStatus);
+    }
+}

--- a/src/main/java/com/programmers/console/CommandLineApplication.java
+++ b/src/main/java/com/programmers/console/CommandLineApplication.java
@@ -4,7 +4,6 @@ import com.programmers.console.util.Command;
 import com.programmers.console.util.VoucherStringSerializer;
 import com.programmers.console.view.Console;
 import com.programmers.voucher.controller.VoucherController;
-import com.programmers.voucher.domain.Discount;
 import com.programmers.voucher.domain.DiscountType;
 import com.programmers.voucher.dto.VoucherRequestDto;
 import com.programmers.voucher.dto.VoucherResponseDto;
@@ -13,7 +12,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
-import java.util.UUID;
 
 @Component
 public class CommandLineApplication {
@@ -61,9 +59,8 @@ public class CommandLineApplication {
 
     private VoucherRequestDto createRequestDtoByUserInput() {
         DiscountType discountType = inputDiscountTypeInfo();
-        long discountInfo = inputDiscountValueInfo();
-        Discount discount = Discount.of(discountType, discountInfo);
-        return new VoucherRequestDto(UUID.randomUUID(), discount);
+        long discountValue = inputDiscountValueInfo();
+        return new VoucherRequestDto(discountType, discountValue);
     }
 
     private DiscountType inputDiscountTypeInfo() {

--- a/src/main/java/com/programmers/voucher/controller/VoucherApiController.java
+++ b/src/main/java/com/programmers/voucher/controller/VoucherApiController.java
@@ -1,0 +1,39 @@
+package com.programmers.voucher.controller;
+
+import com.programmers.voucher.dto.VoucherRequestDto;
+import com.programmers.voucher.dto.VoucherResponseDto;
+import com.programmers.voucher.service.VoucherService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/vouchers")
+public class VoucherApiController {
+
+    private final VoucherService voucherService;
+
+    public VoucherApiController(VoucherService voucherService) {
+        this.voucherService = voucherService;
+    }
+
+    @PostMapping()
+    public ResponseEntity<VoucherResponseDto> create(@RequestBody VoucherRequestDto requestDto) {
+        VoucherResponseDto response = voucherService.create(requestDto);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping()
+    public ResponseEntity<List<VoucherResponseDto>> findAll() {
+        List<VoucherResponseDto> response = voucherService.findVouchers();
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<VoucherResponseDto> findById(@PathVariable UUID id) {
+        VoucherResponseDto response = voucherService.findVoucherById(id);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/programmers/voucher/controller/VoucherApiController.java
+++ b/src/main/java/com/programmers/voucher/controller/VoucherApiController.java
@@ -3,6 +3,8 @@ package com.programmers.voucher.controller;
 import com.programmers.voucher.dto.VoucherRequestDto;
 import com.programmers.voucher.dto.VoucherResponseDto;
 import com.programmers.voucher.service.VoucherService;
+import jakarta.annotation.Nullable;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -22,11 +24,16 @@ public class VoucherApiController {
     @PostMapping()
     public ResponseEntity<VoucherResponseDto> create(@RequestBody VoucherRequestDto requestDto) {
         VoucherResponseDto response = voucherService.create(requestDto);
-        return ResponseEntity.ok(response);
+        return new ResponseEntity<>(response, HttpStatus.CREATED);
     }
 
     @GetMapping()
-    public ResponseEntity<List<VoucherResponseDto>> findAll() {
+    public ResponseEntity<List<VoucherResponseDto>> findAllByCondition(
+            @RequestParam @Nullable String type) {
+        if (type != null) {
+            List<VoucherResponseDto> response = voucherService.findVouchersByType(type);
+            return ResponseEntity.ok(response);
+        }
         List<VoucherResponseDto> response = voucherService.findVouchers();
         return ResponseEntity.ok(response);
     }
@@ -35,5 +42,11 @@ public class VoucherApiController {
     public ResponseEntity<VoucherResponseDto> findById(@PathVariable UUID id) {
         VoucherResponseDto response = voucherService.findVoucherById(id);
         return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteById(@PathVariable UUID id) {
+        voucherService.deleteVoucherById(id);
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 }

--- a/src/main/java/com/programmers/voucher/controller/VoucherApiController.java
+++ b/src/main/java/com/programmers/voucher/controller/VoucherApiController.java
@@ -21,13 +21,13 @@ public class VoucherApiController {
         this.voucherService = voucherService;
     }
 
-    @PostMapping()
+    @PostMapping
     public ResponseEntity<VoucherResponseDto> create(@RequestBody VoucherRequestDto requestDto) {
         VoucherResponseDto response = voucherService.create(requestDto);
         return new ResponseEntity<>(response, HttpStatus.CREATED);
     }
 
-    @GetMapping()
+    @GetMapping
     public ResponseEntity<List<VoucherResponseDto>> findAllByCondition(
             @RequestParam @Nullable String type) {
         if (type != null) {

--- a/src/main/java/com/programmers/voucher/controller/VoucherApiController.java
+++ b/src/main/java/com/programmers/voucher/controller/VoucherApiController.java
@@ -1,10 +1,5 @@
 package com.programmers.voucher.controller;
 
-import com.programmers.voucher.domain.Discount;
-import com.programmers.voucher.domain.DiscountType;
-import com.programmers.voucher.domain.VoucherMapper;
-import com.programmers.voucher.dto.ServiceDto;
-import com.programmers.voucher.dto.VoucherCreateRequest;
 import com.programmers.voucher.dto.VoucherRequestDto;
 import com.programmers.voucher.dto.VoucherResponseDto;
 import com.programmers.voucher.service.VoucherService;
@@ -25,9 +20,8 @@ public class VoucherApiController {
     }
 
     @PostMapping()
-    public ResponseEntity<VoucherResponseDto> create(@RequestBody VoucherCreateRequest requestDto) {
-        ServiceDto serviceDto = VoucherMapper.convertCreateToServiceDto(requestDto);
-        VoucherResponseDto response = voucherService.create(serviceDto);
+    public ResponseEntity<VoucherResponseDto> create(@RequestBody VoucherRequestDto requestDto) {
+        VoucherResponseDto response = voucherService.create(requestDto);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/programmers/voucher/controller/VoucherApiController.java
+++ b/src/main/java/com/programmers/voucher/controller/VoucherApiController.java
@@ -1,5 +1,10 @@
 package com.programmers.voucher.controller;
 
+import com.programmers.voucher.domain.Discount;
+import com.programmers.voucher.domain.DiscountType;
+import com.programmers.voucher.domain.VoucherMapper;
+import com.programmers.voucher.dto.ServiceDto;
+import com.programmers.voucher.dto.VoucherCreateRequest;
 import com.programmers.voucher.dto.VoucherRequestDto;
 import com.programmers.voucher.dto.VoucherResponseDto;
 import com.programmers.voucher.service.VoucherService;
@@ -20,8 +25,9 @@ public class VoucherApiController {
     }
 
     @PostMapping()
-    public ResponseEntity<VoucherResponseDto> create(@RequestBody VoucherRequestDto requestDto) {
-        VoucherResponseDto response = voucherService.create(requestDto);
+    public ResponseEntity<VoucherResponseDto> create(@RequestBody VoucherCreateRequest requestDto) {
+        ServiceDto serviceDto = VoucherMapper.convertCreateToServiceDto(requestDto);
+        VoucherResponseDto response = voucherService.create(serviceDto);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/programmers/voucher/controller/VoucherController.java
+++ b/src/main/java/com/programmers/voucher/controller/VoucherController.java
@@ -1,7 +1,5 @@
 package com.programmers.voucher.controller;
 
-import com.programmers.voucher.domain.VoucherMapper;
-import com.programmers.voucher.dto.ServiceDto;
 import com.programmers.voucher.dto.VoucherRequestDto;
 import com.programmers.voucher.dto.VoucherResponseDto;
 import com.programmers.voucher.service.VoucherService;
@@ -19,8 +17,7 @@ public class VoucherController {
     }
 
     public VoucherResponseDto create (VoucherRequestDto requestDto) {
-        ServiceDto serviceDto = VoucherMapper.convertRequestDtoToServiceDto(requestDto);
-        return voucherService.create(serviceDto);
+        return voucherService.create(requestDto);
     }
 
     public List<VoucherResponseDto> findAll() {

--- a/src/main/java/com/programmers/voucher/controller/VoucherController.java
+++ b/src/main/java/com/programmers/voucher/controller/VoucherController.java
@@ -1,5 +1,7 @@
 package com.programmers.voucher.controller;
 
+import com.programmers.voucher.domain.VoucherMapper;
+import com.programmers.voucher.dto.ServiceDto;
 import com.programmers.voucher.dto.VoucherRequestDto;
 import com.programmers.voucher.dto.VoucherResponseDto;
 import com.programmers.voucher.service.VoucherService;
@@ -17,7 +19,8 @@ public class VoucherController {
     }
 
     public VoucherResponseDto create (VoucherRequestDto requestDto) {
-        return voucherService.create(requestDto);
+        ServiceDto serviceDto = VoucherMapper.convertRequestDtoToServiceDto(requestDto);
+        return voucherService.create(serviceDto);
     }
 
     public List<VoucherResponseDto> findAll() {

--- a/src/main/java/com/programmers/voucher/controller/VoucherController.java
+++ b/src/main/java/com/programmers/voucher/controller/VoucherController.java
@@ -1,7 +1,5 @@
 package com.programmers.voucher.controller;
 
-import com.programmers.voucher.domain.Voucher;
-import com.programmers.voucher.domain.VoucherMapper;
 import com.programmers.voucher.dto.VoucherRequestDto;
 import com.programmers.voucher.dto.VoucherResponseDto;
 import com.programmers.voucher.service.VoucherService;
@@ -19,13 +17,10 @@ public class VoucherController {
     }
 
     public VoucherResponseDto create (VoucherRequestDto requestDto) {
-        Voucher voucher = voucherService.create(requestDto);
-        return VoucherMapper.convertDomainToResponseDto(voucher);
+        return voucherService.create(requestDto);
     }
 
     public List<VoucherResponseDto> findAll() {
-        return voucherService.findVouchers().stream()
-                .map(VoucherMapper::convertDomainToResponseDto)
-                .toList();
+        return voucherService.findVouchers();
     }
 }

--- a/src/main/java/com/programmers/voucher/domain/Discount.java
+++ b/src/main/java/com/programmers/voucher/domain/Discount.java
@@ -12,6 +12,7 @@ public abstract class Discount {
         return switch (discountType) {
             case FIXED -> new FixedDiscount(value);
             case PERCENT -> new PercentDiscount(value);
+            default -> throw new IllegalArgumentException();
         };
     }
 

--- a/src/main/java/com/programmers/voucher/domain/Voucher.java
+++ b/src/main/java/com/programmers/voucher/domain/Voucher.java
@@ -1,5 +1,7 @@
 package com.programmers.voucher.domain;
 
+import com.programmers.voucher.dto.VoucherRequestDto;
+
 import java.time.LocalDateTime;
 import java.util.UUID;
 
@@ -27,6 +29,11 @@ public class Voucher {
         this.discount = discount;
         this.createdAt = createdAt;
         this.expiredAt = expiration;
+    }
+
+    public static Voucher from(UUID voucherId, VoucherRequestDto requestDto) {
+        Discount discount = Discount.of(requestDto.discountType(), requestDto.value());
+        return new Voucher(voucherId, discount, LocalDateTime.now());
     }
 
     public long discountWith(long itemPrice, LocalDateTime usedAt) {

--- a/src/main/java/com/programmers/voucher/domain/VoucherMapper.java
+++ b/src/main/java/com/programmers/voucher/domain/VoucherMapper.java
@@ -16,8 +16,10 @@ public class VoucherMapper {
     }
 
     public static VoucherResponseDto convertDomainToResponseDto(Voucher voucher) {
-        return new VoucherResponseDto(voucher.getVoucherId(), voucher.getDiscount(),
-                voucher.getCreatedAt());
+        return new VoucherResponseDto(voucher.getVoucherId(),
+                voucher.getDiscount(),
+                voucher.getCreatedAt(),
+                voucher.getExpiredAt());
     }
 
     public static VoucherEntity convertDomainToEntity(Voucher voucher) {

--- a/src/main/java/com/programmers/voucher/domain/VoucherMapper.java
+++ b/src/main/java/com/programmers/voucher/domain/VoucherMapper.java
@@ -1,12 +1,9 @@
 package com.programmers.voucher.domain;
 
-import com.programmers.voucher.dto.ServiceDto;
-import com.programmers.voucher.dto.VoucherCreateRequest;
 import com.programmers.voucher.dto.VoucherRequestDto;
 import com.programmers.voucher.dto.VoucherResponseDto;
 import com.programmers.voucher.entity.VoucherEntity;
 
-import java.time.LocalDateTime;
 import java.util.UUID;
 
 public class VoucherMapper {
@@ -14,8 +11,8 @@ public class VoucherMapper {
     private VoucherMapper() {
     }
 
-    public static Voucher convertRequestDtoToDomain(VoucherRequestDto requestDto) {
-        return new Voucher(requestDto.voucherId(), requestDto.discount(), LocalDateTime.now());
+    public static Voucher convertRequestDtoToDomain(UUID voucherId, VoucherRequestDto requestDto) {
+        return Voucher.from(voucherId, requestDto);
     }
 
     public static VoucherResponseDto convertDomainToResponseDto(Voucher voucher) {
@@ -35,16 +32,4 @@ public class VoucherMapper {
                 voucherEntity.getCreatedDate());
     }
 
-    public static ServiceDto convertCreateToServiceDto(VoucherCreateRequest createRequest) {
-        Discount discount = Discount.of(createRequest.discountType(), createRequest.value());
-        return new ServiceDto(UUID.randomUUID(), discount);
-    }
-
-    public static ServiceDto convertRequestDtoToServiceDto(VoucherRequestDto requestDto) {
-        return new ServiceDto(requestDto.voucherId(), requestDto.discount());
-    }
-
-    public static Voucher convertServiceToDomain(ServiceDto serviceDto) {
-        return new Voucher(serviceDto.voucherId(), serviceDto.discount(), LocalDateTime.now());
-    }
 }

--- a/src/main/java/com/programmers/voucher/domain/VoucherMapper.java
+++ b/src/main/java/com/programmers/voucher/domain/VoucherMapper.java
@@ -1,10 +1,13 @@
 package com.programmers.voucher.domain;
 
+import com.programmers.voucher.dto.ServiceDto;
+import com.programmers.voucher.dto.VoucherCreateRequest;
 import com.programmers.voucher.dto.VoucherRequestDto;
 import com.programmers.voucher.dto.VoucherResponseDto;
 import com.programmers.voucher.entity.VoucherEntity;
 
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 public class VoucherMapper {
 
@@ -30,5 +33,18 @@ public class VoucherMapper {
     public static Voucher convertEntityToDomain(VoucherEntity voucherEntity) {
         return new Voucher(voucherEntity.getVoucherId(), voucherEntity.getDiscount(),
                 voucherEntity.getCreatedDate());
+    }
+
+    public static ServiceDto convertCreateToServiceDto(VoucherCreateRequest createRequest) {
+        Discount discount = Discount.of(createRequest.discountType(), createRequest.value());
+        return new ServiceDto(UUID.randomUUID(), discount);
+    }
+
+    public static ServiceDto convertRequestDtoToServiceDto(VoucherRequestDto requestDto) {
+        return new ServiceDto(requestDto.voucherId(), requestDto.discount());
+    }
+
+    public static Voucher convertServiceToDomain(ServiceDto serviceDto) {
+        return new Voucher(serviceDto.voucherId(), serviceDto.discount(), LocalDateTime.now());
     }
 }

--- a/src/main/java/com/programmers/voucher/dto/ServiceDto.java
+++ b/src/main/java/com/programmers/voucher/dto/ServiceDto.java
@@ -1,0 +1,8 @@
+package com.programmers.voucher.dto;
+
+import com.programmers.voucher.domain.Discount;
+
+import java.util.UUID;
+
+public record ServiceDto(UUID voucherId, Discount discount) {
+}

--- a/src/main/java/com/programmers/voucher/dto/ServiceDto.java
+++ b/src/main/java/com/programmers/voucher/dto/ServiceDto.java
@@ -1,8 +1,0 @@
-package com.programmers.voucher.dto;
-
-import com.programmers.voucher.domain.Discount;
-
-import java.util.UUID;
-
-public record ServiceDto(UUID voucherId, Discount discount) {
-}

--- a/src/main/java/com/programmers/voucher/dto/VoucherCreateRequest.java
+++ b/src/main/java/com/programmers/voucher/dto/VoucherCreateRequest.java
@@ -1,0 +1,6 @@
+package com.programmers.voucher.dto;
+
+import com.programmers.voucher.domain.DiscountType;
+
+public record VoucherCreateRequest(DiscountType discountType, long value){
+}

--- a/src/main/java/com/programmers/voucher/dto/VoucherCreateRequest.java
+++ b/src/main/java/com/programmers/voucher/dto/VoucherCreateRequest.java
@@ -1,6 +1,0 @@
-package com.programmers.voucher.dto;
-
-import com.programmers.voucher.domain.DiscountType;
-
-public record VoucherCreateRequest(DiscountType discountType, long value){
-}

--- a/src/main/java/com/programmers/voucher/dto/VoucherRequestDto.java
+++ b/src/main/java/com/programmers/voucher/dto/VoucherRequestDto.java
@@ -1,8 +1,6 @@
 package com.programmers.voucher.dto;
 
-import com.programmers.voucher.domain.Discount;
+import com.programmers.voucher.domain.DiscountType;
 
-import java.util.UUID;
-
-public record VoucherRequestDto(UUID voucherId, Discount discount) {
+public record VoucherRequestDto(DiscountType discountType, long value) {
 }

--- a/src/main/java/com/programmers/voucher/dto/VoucherResponseDto.java
+++ b/src/main/java/com/programmers/voucher/dto/VoucherResponseDto.java
@@ -5,5 +5,9 @@ import com.programmers.voucher.domain.Discount;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
-public record VoucherResponseDto(UUID voucherId, Discount discount, LocalDateTime createdAt) {
+public record VoucherResponseDto(
+        UUID voucherId,
+        Discount discount,
+        LocalDateTime createdAt,
+        LocalDateTime expiredAt) {
 }

--- a/src/main/java/com/programmers/voucher/service/VoucherService.java
+++ b/src/main/java/com/programmers/voucher/service/VoucherService.java
@@ -1,6 +1,5 @@
 package com.programmers.voucher.service;
 
-import com.programmers.voucher.dto.ServiceDto;
 import com.programmers.voucher.dto.VoucherRequestDto;
 import com.programmers.voucher.dto.VoucherResponseDto;
 
@@ -9,7 +8,7 @@ import java.util.UUID;
 
 public interface VoucherService {
 
-    VoucherResponseDto create(ServiceDto serviceDto);
+    VoucherResponseDto create(VoucherRequestDto requestDto);
 
     List<VoucherResponseDto> findVouchers();
 

--- a/src/main/java/com/programmers/voucher/service/VoucherService.java
+++ b/src/main/java/com/programmers/voucher/service/VoucherService.java
@@ -12,5 +12,5 @@ public interface VoucherService {
 
     List<VoucherResponseDto> findVouchers();
 
-    VoucherResponseDto findVoucher(UUID voucherId);
+    VoucherResponseDto findVoucherById(UUID voucherId);
 }

--- a/src/main/java/com/programmers/voucher/service/VoucherService.java
+++ b/src/main/java/com/programmers/voucher/service/VoucherService.java
@@ -1,5 +1,6 @@
 package com.programmers.voucher.service;
 
+import com.programmers.voucher.dto.ServiceDto;
 import com.programmers.voucher.dto.VoucherRequestDto;
 import com.programmers.voucher.dto.VoucherResponseDto;
 
@@ -8,7 +9,7 @@ import java.util.UUID;
 
 public interface VoucherService {
 
-    VoucherResponseDto create(VoucherRequestDto requestDto);
+    VoucherResponseDto create(ServiceDto serviceDto);
 
     List<VoucherResponseDto> findVouchers();
 

--- a/src/main/java/com/programmers/voucher/service/VoucherService.java
+++ b/src/main/java/com/programmers/voucher/service/VoucherService.java
@@ -1,16 +1,16 @@
 package com.programmers.voucher.service;
 
-import com.programmers.voucher.domain.Voucher;
 import com.programmers.voucher.dto.VoucherRequestDto;
+import com.programmers.voucher.dto.VoucherResponseDto;
 
 import java.util.List;
 import java.util.UUID;
 
 public interface VoucherService {
 
-    Voucher create(VoucherRequestDto requestDto);
+    VoucherResponseDto create(VoucherRequestDto requestDto);
 
-    List<Voucher> findVouchers();
+    List<VoucherResponseDto> findVouchers();
 
-    Voucher findVoucher(UUID voucherId);
+    VoucherResponseDto findVoucher(UUID voucherId);
 }

--- a/src/main/java/com/programmers/voucher/service/VoucherService.java
+++ b/src/main/java/com/programmers/voucher/service/VoucherService.java
@@ -13,4 +13,8 @@ public interface VoucherService {
     List<VoucherResponseDto> findVouchers();
 
     VoucherResponseDto findVoucherById(UUID voucherId);
+
+    List<VoucherResponseDto> findVouchersByType(String type);
+
+    void deleteVoucherById(UUID voucherId);
 }

--- a/src/main/java/com/programmers/voucher/service/VoucherServiceImpl.java
+++ b/src/main/java/com/programmers/voucher/service/VoucherServiceImpl.java
@@ -35,7 +35,7 @@ public class VoucherServiceImpl implements VoucherService {
                 .toList();
     }
 
-    public VoucherResponseDto findVoucher(UUID voucherID) {
+    public VoucherResponseDto findVoucherById(UUID voucherID) {
         Voucher voucher = voucherRepository.findById(voucherID);
         return VoucherMapper.convertDomainToResponseDto(voucher);
     }

--- a/src/main/java/com/programmers/voucher/service/VoucherServiceImpl.java
+++ b/src/main/java/com/programmers/voucher/service/VoucherServiceImpl.java
@@ -2,6 +2,7 @@ package com.programmers.voucher.service;
 
 import com.programmers.voucher.domain.Voucher;
 import com.programmers.voucher.domain.VoucherMapper;
+import com.programmers.voucher.dto.ServiceDto;
 import com.programmers.voucher.dto.VoucherRequestDto;
 import com.programmers.voucher.dto.VoucherResponseDto;
 import com.programmers.voucher.repository.VoucherRepository;
@@ -22,8 +23,8 @@ public class VoucherServiceImpl implements VoucherService {
     }
 
     @Transactional
-    public VoucherResponseDto create(VoucherRequestDto requestDto) {
-        Voucher voucher = VoucherMapper.convertRequestDtoToDomain(requestDto);
+    public VoucherResponseDto create(ServiceDto serviceDto) {
+        Voucher voucher = VoucherMapper.convertServiceToDomain(serviceDto);
         voucherRepository.save(voucher);
         return VoucherMapper.convertDomainToResponseDto(voucher);
     }

--- a/src/main/java/com/programmers/voucher/service/VoucherServiceImpl.java
+++ b/src/main/java/com/programmers/voucher/service/VoucherServiceImpl.java
@@ -40,4 +40,15 @@ public class VoucherServiceImpl implements VoucherService {
         Voucher voucher = voucherRepository.findById(voucherID);
         return VoucherMapper.convertDomainToResponseDto(voucher);
     }
+
+    public List<VoucherResponseDto> findVouchersByType(String type) {
+        List<Voucher> vouchers = voucherRepository.findByType(type);
+        return vouchers.stream()
+                .map(VoucherMapper::convertDomainToResponseDto)
+                .toList();
+    }
+
+    public void deleteVoucherById(UUID voucherId) {
+        voucherRepository.deleteById(voucherId);
+    }
 }

--- a/src/main/java/com/programmers/voucher/service/VoucherServiceImpl.java
+++ b/src/main/java/com/programmers/voucher/service/VoucherServiceImpl.java
@@ -2,7 +2,6 @@ package com.programmers.voucher.service;
 
 import com.programmers.voucher.domain.Voucher;
 import com.programmers.voucher.domain.VoucherMapper;
-import com.programmers.voucher.dto.ServiceDto;
 import com.programmers.voucher.dto.VoucherRequestDto;
 import com.programmers.voucher.dto.VoucherResponseDto;
 import com.programmers.voucher.repository.VoucherRepository;
@@ -23,8 +22,8 @@ public class VoucherServiceImpl implements VoucherService {
     }
 
     @Transactional
-    public VoucherResponseDto create(ServiceDto serviceDto) {
-        Voucher voucher = VoucherMapper.convertServiceToDomain(serviceDto);
+    public VoucherResponseDto create(VoucherRequestDto requestDto) {
+        Voucher voucher = VoucherMapper.convertRequestDtoToDomain(UUID.randomUUID(), requestDto);
         voucherRepository.save(voucher);
         return VoucherMapper.convertDomainToResponseDto(voucher);
     }
@@ -36,6 +35,7 @@ public class VoucherServiceImpl implements VoucherService {
                 .toList();
     }
 
+    //파라미터의 변경을 예측가능 /변경성이 낮음 /일반적이기 때문
     public VoucherResponseDto findVoucherById(UUID voucherID) {
         Voucher voucher = voucherRepository.findById(voucherID);
         return VoucherMapper.convertDomainToResponseDto(voucher);

--- a/src/main/java/com/programmers/voucher/service/VoucherServiceImpl.java
+++ b/src/main/java/com/programmers/voucher/service/VoucherServiceImpl.java
@@ -3,6 +3,7 @@ package com.programmers.voucher.service;
 import com.programmers.voucher.domain.Voucher;
 import com.programmers.voucher.domain.VoucherMapper;
 import com.programmers.voucher.dto.VoucherRequestDto;
+import com.programmers.voucher.dto.VoucherResponseDto;
 import com.programmers.voucher.repository.VoucherRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,16 +22,21 @@ public class VoucherServiceImpl implements VoucherService {
     }
 
     @Transactional
-    public Voucher create(VoucherRequestDto requestDto) {
+    public VoucherResponseDto create(VoucherRequestDto requestDto) {
         Voucher voucher = VoucherMapper.convertRequestDtoToDomain(requestDto);
-        return voucherRepository.save(voucher);
+        voucherRepository.save(voucher);
+        return VoucherMapper.convertDomainToResponseDto(voucher);
     }
 
-    public List<Voucher> findVouchers() {
-        return voucherRepository.findAll();
+    public List<VoucherResponseDto> findVouchers() {
+        List<Voucher> vouchers = voucherRepository.findAll();
+        return vouchers.stream()
+                .map(VoucherMapper::convertDomainToResponseDto)
+                .toList();
     }
 
-    public Voucher findVoucher(UUID voucherID) {
-        return voucherRepository.findById(voucherID);
+    public VoucherResponseDto findVoucher(UUID voucherID) {
+        Voucher voucher = voucherRepository.findById(voucherID);
+        return VoucherMapper.convertDomainToResponseDto(voucher);
     }
 }

--- a/src/test/java/com/programmers/customer/repository/JdbcCustomerRepositoryTest.java
+++ b/src/test/java/com/programmers/customer/repository/JdbcCustomerRepositoryTest.java
@@ -58,12 +58,11 @@ class JdbcCustomerRepositoryTest {
     @DisplayName("저장된 모든 고객을 조회할 수 있다.")
     @Test
     void findAllCustomersTest() {
-        Customer testCustomer = new Customer(UUID.randomUUID(), "고객", LocalDateTime.now());
-        Customer testCustomer2 = new Customer(UUID.randomUUID(), "고객", LocalDateTime.now());
-        Customer testCustomer3 = new Customer(UUID.randomUUID(), "고객", LocalDateTime.now());
-        jdbcCustomerRepository.save(testCustomer);
-        jdbcCustomerRepository.save(testCustomer2);
-        jdbcCustomerRepository.save(testCustomer3);
+        for(int i = 0; i < 3; i++) {
+            String name = "고객" + i;
+            Customer testCustomer = new Customer(UUID.randomUUID(), name, LocalDateTime.now());
+            jdbcCustomerRepository.save(testCustomer);
+        }
 
         List<Customer> customers = jdbcCustomerRepository.findAll();
 

--- a/src/test/java/com/programmers/voucher/domain/DiscountValueTest.java
+++ b/src/test/java/com/programmers/voucher/domain/DiscountValueTest.java
@@ -4,7 +4,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class DiscountValueTest {
 

--- a/src/test/java/com/programmers/voucher/repository/JdbcVoucherRepositoryTest.java
+++ b/src/test/java/com/programmers/voucher/repository/JdbcVoucherRepositoryTest.java
@@ -24,7 +24,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @ActiveProfiles("test")
 @JdbcTest
-//@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 class JdbcVoucherRepositoryTest {
 
     @TestConfiguration

--- a/src/test/java/com/programmers/voucher/repository/JdbcVoucherRepositoryTest.java
+++ b/src/test/java/com/programmers/voucher/repository/JdbcVoucherRepositoryTest.java
@@ -61,12 +61,10 @@ class JdbcVoucherRepositoryTest {
     @DisplayName("DB에서 모든 바우처를 조회할 수 있다.")
     @Test
     void findAllTest() {
-        Voucher testVoucher = new Voucher(UUID.randomUUID(), new FixedDiscount(100), LocalDateTime.now());
-        Voucher testVoucher2 = new Voucher(UUID.randomUUID(), new FixedDiscount(100), LocalDateTime.now());
-        Voucher testVoucher3 = new Voucher(UUID.randomUUID(), new FixedDiscount(100), LocalDateTime.now());
-        jdbcVoucherRepository.save(testVoucher);
-        jdbcVoucherRepository.save(testVoucher2);
-        jdbcVoucherRepository.save(testVoucher3);
+        for (int i = 0; i < 3; i++) {
+            Voucher testVoucher = new Voucher(UUID.randomUUID(), new FixedDiscount(100), LocalDateTime.now());
+            jdbcVoucherRepository.save(testVoucher);
+        }
 
         List<Voucher> vouchers = jdbcVoucherRepository.findAll();
 

--- a/src/test/java/com/programmers/voucher/repository/JdbcVoucherRepositoryTest.java
+++ b/src/test/java/com/programmers/voucher/repository/JdbcVoucherRepositoryTest.java
@@ -21,7 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @ActiveProfiles("test")
 @JdbcTest
-@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+//@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 class JdbcVoucherRepositoryTest {
 
     @TestConfiguration
@@ -55,7 +55,7 @@ class JdbcVoucherRepositoryTest {
 
         Voucher storedVoucher = jdbcVoucherRepository.findById(id);
 
-        assertThat(storedVoucher.getVoucherId()).isNotEqualTo(id);
+        assertThat(storedVoucher.getVoucherId()).isEqualTo(id);
     }
 
     @DisplayName("DB에서 모든 바우처를 조회할 수 있다.")

--- a/src/test/java/com/programmers/voucher/service/VoucherServiceTest.java
+++ b/src/test/java/com/programmers/voucher/service/VoucherServiceTest.java
@@ -3,6 +3,8 @@ package com.programmers.voucher.service;
 import com.programmers.voucher.domain.Discount;
 import com.programmers.voucher.domain.DiscountType;
 import com.programmers.voucher.domain.FixedDiscount;
+import com.programmers.voucher.domain.VoucherMapper;
+import com.programmers.voucher.dto.ServiceDto;
 import com.programmers.voucher.dto.VoucherRequestDto;
 import com.programmers.voucher.dto.VoucherResponseDto;
 import com.programmers.voucher.repository.MemoryVoucherRepository;
@@ -33,8 +35,9 @@ class VoucherServiceTest {
         Discount discount = Discount.of(DiscountType.of(command), value);
         UUID id = UUID.randomUUID();
         VoucherRequestDto requestDto = new VoucherRequestDto(id, discount);
+        ServiceDto serviceDto = VoucherMapper.convertRequestDtoToServiceDto(requestDto);
 
-        VoucherResponseDto voucher = voucherService.create(requestDto);
+        VoucherResponseDto voucher = voucherService.create(serviceDto);
 
         assertThat(voucher).isNotNull();
     }
@@ -45,8 +48,9 @@ class VoucherServiceTest {
         Discount discount = new FixedDiscount(123456);
         UUID id = UUID.randomUUID();
         VoucherRequestDto requestDto = new VoucherRequestDto(id, discount);
+        ServiceDto serviceDto = VoucherMapper.convertRequestDtoToServiceDto(requestDto);
 
-        VoucherResponseDto expected = voucherService.create(requestDto);
+        VoucherResponseDto expected = voucherService.create(serviceDto);
         VoucherResponseDto actual = voucherService.findVoucherById(id);
 
         assertThat(expected).isEqualTo(actual);

--- a/src/test/java/com/programmers/voucher/service/VoucherServiceTest.java
+++ b/src/test/java/com/programmers/voucher/service/VoucherServiceTest.java
@@ -3,7 +3,6 @@ package com.programmers.voucher.service;
 import com.programmers.voucher.domain.Discount;
 import com.programmers.voucher.domain.DiscountType;
 import com.programmers.voucher.domain.FixedDiscount;
-import com.programmers.voucher.domain.Voucher;
 import com.programmers.voucher.dto.VoucherRequestDto;
 import com.programmers.voucher.dto.VoucherResponseDto;
 import com.programmers.voucher.repository.MemoryVoucherRepository;
@@ -48,7 +47,7 @@ class VoucherServiceTest {
         VoucherRequestDto requestDto = new VoucherRequestDto(id, discount);
 
         VoucherResponseDto expected = voucherService.create(requestDto);
-        VoucherResponseDto actual = voucherService.findVoucher(id);
+        VoucherResponseDto actual = voucherService.findVoucherById(id);
 
         assertThat(expected).isEqualTo(actual);
     }

--- a/src/test/java/com/programmers/voucher/service/VoucherServiceTest.java
+++ b/src/test/java/com/programmers/voucher/service/VoucherServiceTest.java
@@ -1,10 +1,6 @@
 package com.programmers.voucher.service;
 
-import com.programmers.voucher.domain.Discount;
 import com.programmers.voucher.domain.DiscountType;
-import com.programmers.voucher.domain.FixedDiscount;
-import com.programmers.voucher.domain.VoucherMapper;
-import com.programmers.voucher.dto.ServiceDto;
 import com.programmers.voucher.dto.VoucherRequestDto;
 import com.programmers.voucher.dto.VoucherResponseDto;
 import com.programmers.voucher.repository.MemoryVoucherRepository;
@@ -12,8 +8,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
-
-import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -32,12 +26,10 @@ class VoucherServiceTest {
             , "1, 30"
     })
     void createVoucherTest(String command, long value) {
-        Discount discount = Discount.of(DiscountType.of(command), value);
-        UUID id = UUID.randomUUID();
-        VoucherRequestDto requestDto = new VoucherRequestDto(id, discount);
-        ServiceDto serviceDto = VoucherMapper.convertRequestDtoToServiceDto(requestDto);
+        DiscountType discountType = DiscountType.of(command);
+        VoucherRequestDto requestDto = new VoucherRequestDto(discountType, value);
 
-        VoucherResponseDto voucher = voucherService.create(serviceDto);
+        VoucherResponseDto voucher = voucherService.create(requestDto);
 
         assertThat(voucher).isNotNull();
     }
@@ -45,13 +37,11 @@ class VoucherServiceTest {
     @DisplayName("바우처를 생성했던 ID로 바우처 조회가 가능한지")
     @Test
     void findByIdTest() {
-        Discount discount = new FixedDiscount(123456);
-        UUID id = UUID.randomUUID();
-        VoucherRequestDto requestDto = new VoucherRequestDto(id, discount);
-        ServiceDto serviceDto = VoucherMapper.convertRequestDtoToServiceDto(requestDto);
+        DiscountType discountType = DiscountType.FIXED;
+        VoucherRequestDto requestDto = new VoucherRequestDto(discountType, 100);
+        VoucherResponseDto expected = voucherService.create(requestDto);
 
-        VoucherResponseDto expected = voucherService.create(serviceDto);
-        VoucherResponseDto actual = voucherService.findVoucherById(id);
+        VoucherResponseDto actual = voucherService.findVoucherById(expected.voucherId());
 
         assertThat(expected).isEqualTo(actual);
     }

--- a/src/test/java/com/programmers/voucher/service/VoucherServiceTest.java
+++ b/src/test/java/com/programmers/voucher/service/VoucherServiceTest.java
@@ -5,6 +5,7 @@ import com.programmers.voucher.domain.DiscountType;
 import com.programmers.voucher.domain.FixedDiscount;
 import com.programmers.voucher.domain.Voucher;
 import com.programmers.voucher.dto.VoucherRequestDto;
+import com.programmers.voucher.dto.VoucherResponseDto;
 import com.programmers.voucher.repository.MemoryVoucherRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -34,7 +35,7 @@ class VoucherServiceTest {
         UUID id = UUID.randomUUID();
         VoucherRequestDto requestDto = new VoucherRequestDto(id, discount);
 
-        Voucher voucher = voucherService.create(requestDto);
+        VoucherResponseDto voucher = voucherService.create(requestDto);
 
         assertThat(voucher).isNotNull();
     }
@@ -46,8 +47,8 @@ class VoucherServiceTest {
         UUID id = UUID.randomUUID();
         VoucherRequestDto requestDto = new VoucherRequestDto(id, discount);
 
-        Voucher expected = voucherService.create(requestDto);
-        Voucher actual = voucherService.findVoucher(id);
+        VoucherResponseDto expected = voucherService.create(requestDto);
+        VoucherResponseDto actual = voucherService.findVoucher(id);
 
         assertThat(expected).isEqualTo(actual);
     }

--- a/src/test/resources/schema.sql
+++ b/src/test/resources/schema.sql
@@ -3,7 +3,7 @@ DROP TABLE IF EXISTS voucher;
 DROP TABLE IF EXISTS customer;
 
 CREATE TABLE voucher (
-    id VARCHAR(36),
+    id CHAR(36),
     type VARCHAR(20) NOT NULL,
     discount_value int NOT NULL,
     created_at timestamp default current_timestamp,
@@ -12,7 +12,7 @@ CREATE TABLE voucher (
 );
 
 CREATE TABLE customer (
-    id VARCHAR(36),
+    id CHAR(36),
     name VARCHAR(10),
     created_at timestamp default current_timestamp,
     modified_at timestamp,
@@ -20,7 +20,7 @@ CREATE TABLE customer (
 );
 
 CREATE TABLE wallet (
-    id VARCHAR(36),
+    id CHAR(36),
     voucher_id VARCHAR(36),
     customer_id VARCHAR(36),
     foreign key (voucher_id) references voucher (id)


### PR DESCRIPTION

## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->
- https://github.com/prgrms-be-devcourse/springboot-basic/commit/86b3b76c57d9d8a494fec92e1b4fb4f8c13563f6 테스트 application.yml 설정
- https://github.com/prgrms-be-devcourse/springboot-basic/commit/a90c685c8d89e903f76d6dbe9e4edf572c236219 `@Transactional 삭제`
- https://github.com/prgrms-be-devcourse/springboot-basic/commit/35535d4ff83d4525673f07b347b845fc8b65b0ff `@TestConfiguration` 적용
- c9666e1e50ae71687bed82376e197f365b4089fb `DiscountValue` 테스트 케이스 수정
- `H2` 의존성에 관한 피드백 -> 개더에서 말씀해주신 것을 참고하여 `@ConditionalOnProperty` 이외의 다양한 애노테이션을 통해서 설정을 해보았는데 정상적으로 동작하지 않았습니다. 해당 부분은 좀 더 알아보고 적용해보도록 하겠습니다!
- https://github.com/prgrms-be-devcourse/springboot-basic/commit/c409a13b78535f91e0e4eaa3b9d2ca7ca4e96f55 update용 dto 추가
- `soft delete` -> soft delete 를 사용하면 얻을 수 있는 장점으로 삭제된 데이터의 복구 및 통계 활용 등에서 장점이 있을 것 같습니다. 또한 다른 예시로 악의적인 행동을 한 후 스스로 탈퇴한 고객 정보가 hard delete 되는 경우 추적하기 어렵다는 점 등을 알게 되었습니다. 이를 통해 soft delete와 hard delete의 사용 시점에 대한 고민을 해보게 되는 계기가 되었습니다!
현재 제가 설계한 프로젝트에서는 지갑 부분에서 voucherId와 customerId에 대해 캐스캐이딩 처리를 해주는 식으로 설계를 하기도 했으며, 삭제한 정보를 추후에 활용하게 되는 요구 사항은 없을 것이라 판단하여 hard delete를 유지하도록 하였습니다!
- `@Transcational(readOnly = true)` 적용 이유 -> 읽기 전용 트랜잭셔널을 사용하면 영속성 컨텍스트가 Entity 변경 감지에 대한 스냅샷을 보관할 필요가 없기 때문에 성능이 올라가는 것으로 알고 있습니다. 현재 서비스에서 대부분의 메서드는 조회 관련 쿼리이기 때문에 전체적으로 읽기 전용 트랜잭셔널을 적용하고, CRUD가 발생하는 메서드에서는 일반적인 트른잭셔널을 적용해 주었습니다!
- https://github.com/prgrms-be-devcourse/springboot-basic/commit/d7a5d134267377015fcf427a08d7642ff6e272a8 테스트 케이스 반복문으로 변경
- 113f44cc86b06d81e6c86d188ccac0bebb1f6e3a `Service 에서 사용되는 dto`  -> 새벽에 도진님께서 남겨주셨던 피드백을 통해 요청에 대한 정보 생성 시점을 변경하여 콘솔과 api 모두에서 동일한 dto를 사용할 수 있도록 변경하였습니다. 

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
